### PR TITLE
Replace device_state_attributes with extra_state_attributes

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -94,7 +94,7 @@ class OsloWasteSensor(Entity):
             return (self._state - date.today()).days
 
     @property
-    def device_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict:
         return self._attributes
 
     @property


### PR DESCRIPTION
Avoid warning:
2022-03-10 21:50:34 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.xxxx (<class 'custom_components.oslo_waste.sensor.OsloWasteSensor'>) implements device_state_attributes. Please report it to the custom component author.

See https://github.com/home-assistant/core/pull/55734 and https://github.com/home-assistant/core/pull/47304